### PR TITLE
Fix weather tool detection in pickToolFromText

### DIFF
--- a/lib/tools/index.ts
+++ b/lib/tools/index.ts
@@ -13,7 +13,7 @@ export type ToolName = keyof typeof tools;
 
 export function pickToolFromText(text: string): Tool | null {
   const q = text.toLowerCase();
-  if (q.includes("udes("weather") || q.startsWith("wx ")) return tools.weather;
+  if (q.includes("weather") || q.startsWith("wx ")) return tools.weather;
   if (q.includes("image") || q.startsWith("img ")) return tools.image_search;
   if (q.includes("search") || q.includes("lookup") || q.includes("find")) return tools.web_search;
   return null;


### PR DESCRIPTION
This patch fixes a bug in pickToolFromText where the weather tool branch was broken due to a typo in the string check. The condition now correctly uses q.includes("weather") (instead of the corrupted includes call) while preserving the existing wx prefix handling. 

What changed:
- lib/tools/index.ts: Corrected the weather tool detection to respond to queries containing "weather" or starting with "wx ".

Impact:
- Weather-related queries will now properly route to the weather tool. Image search and web search branches remain unchanged.

---

> This pull request was co-created with Cosine Genie

Original Task: [blank-projectl/5r909z6flls5](https://cosine.sh/hq3m6gvk8qkr/blank-projectl/task/5r909z6flls5)
Author: bnyheart
